### PR TITLE
Fix @octokit/rest deprecation warning

### DIFF
--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -1,6 +1,6 @@
 import createCheck from 'create-check';
 import path from 'path';
-import Octokit from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import eslint from 'eslint';
 
 const APP_ID = 38817;


### PR DESCRIPTION
Fixes the deprecation warning from `@octokit/rest`:

```
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
```