### PR TITLE
Allow to pass check name environment variable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,3 +65,7 @@ Once you have generated a key, open the file that is downloaded and copy to text
 ### 4. Set `GH_API` (enterprise only)
 
 To get this package to work on github enterprise instances you will need to set the `GH_API` environment variable to a url pointing towards your enterprise GitHub's API.
+
+### 5. (optional) Set `GH_CHECK_NAME`
+
+If the default check name conflicts with something, you can override it by passing `GH_CHECK_NAME` environment variable.

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -90,7 +90,7 @@ export default async (results: eslint.CLIEngine.LintResult[]) => {
 
   return createCheck({
     tool: 'ESLint',
-    name: process.env.GITHUB_CHECK_NAME || 'Check Code for Errors',
+    name: process.env.GH_CHECK_NAME || 'Check Code for Errors',
     annotations: createAnnotations(results),
     errorCount,
     warningCount,

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -90,7 +90,7 @@ export default async (results: eslint.CLIEngine.LintResult[]) => {
 
   return createCheck({
     tool: 'ESLint',
-    name: 'Check Code for Errors',
+    name: process.env.GITHUB_CHECK_NAME || 'Check Code for Errors',
     annotations: createAnnotations(results),
     errorCount,
     warningCount,


### PR DESCRIPTION
this covers at least two use cases:

1. For some people the check name may conflict with an existing one, if they are using their own github app.
2. In some monorepos there are multiple jest runs happening in series for multiple different packages in scope of one codebuild run. Without an ability to override the check name we are stuck with only last package results being reported.

This would allow to work around those

related PR: https://github.com/hipstersmoothie/jest-github-reporter/pull/150