### PR TITLE
annotate files relative to git root, instead of cwd, so that it works in nested packages in monorepos (+fix lint)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
   "rules": {
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/camelcase": 0,
+    "camelcase": 0,
     "complexity": 0,
     "import/extensions": 0
   }

--- a/package.json
+++ b/package.json
@@ -34,17 +34,19 @@
   },
   "dependencies": {
     "create-check": "^0.6.0",
-    "eslint-formatter-pretty": "^3.0.0"
+    "eslint-formatter-pretty": "^3.0.0",
+    "execa": "^1.0.0"
   },
   "devDependencies": {
+    "@types/execa": "^0.9.0",
     "@types/env-ci": "3.1.0",
     "@types/eslint": "6.8.0",
     "@types/lru-cache": "5.1.0",
-    "@typescript-eslint/eslint-plugin": "2.32.0",
-    "@typescript-eslint/parser": "2.32.0",
+    "@typescript-eslint/eslint-plugin": "^5.54.0",
+    "@typescript-eslint/parser": "^5.54.0",
     "auto": "^10.43.0",
     "auto-config-hipstersmoothie": "^4.0.0",
-    "eslint": "7.0.0",
+    "eslint": "^7.1.0",
     "eslint-config-airbnb": "18.1.0",
     "eslint-config-airbnb-base": "14.1.0",
     "eslint-config-prettier": "6.11.0",


### PR DESCRIPTION

used execa v1 instead of the latest one because dependencies already use it. just to dedupe versions