### PR TITLE
Improve documentation and add ESLINT_PRIVATE_KEY_BASE64 variable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Then just use the formatter and it will report errors and warnings on PRs!
 eslint --format github file.js
 ```
 
-## Using you own GitHub App
+## Using you own GitHub App (recommended)
 
 You might not want to use our github app for the formatter.
 
@@ -52,6 +52,11 @@ Go to [this page](https://github.com/settings/apps) to create a new GitHub app. 
 
 Then hit `Save Changes` and you're all done setting up your GitHub app.
 
+You need to configure Permissions for your GitHub app. You need to set the following permissions:
+
+- `Checks` - `Read & Write`
+- `Metadata` - `Read-only`
+
 ### 2. Set `ESLINT_APP_ID` environment variable
 
 Your GitHub application's ID. This can be found at the top of your GitHub app's edit page.
@@ -62,6 +67,15 @@ The private RSA key for your application. The prompt to generate the RSA key is 
 
 Once you have generated a key, open the file that is downloaded and copy to text into the `PRIVATE_KEY` environment variable.
 
+When using GitHub Actions, you can use the environment variable `ESLINT_PRIVATE_KEY_BASE64` to set the private key base64 encoded.
+This fix the issue with the new line characters in the private key.
+
+To encode the private key, you can use the following command:
+
+```sh
+cat private-key.pem | base64
+```
+
 ### 4. Set `GH_API` (enterprise only)
 
 To get this package to work on github enterprise instances you will need to set the `GH_API` environment variable to a url pointing towards your enterprise GitHub's API.
@@ -69,3 +83,27 @@ To get this package to work on github enterprise instances you will need to set 
 ### 5. (optional) Set `GH_CHECK_NAME`
 
 If the default check name conflicts with something, you can override it by passing `GH_CHECK_NAME` environment variable.
+
+### Example for GitHub Actions
+
+> **Warning**
+> It is strongly recommended to create your own GitHub app and never share your private key with third parties.
+> Otherwise, unauthorized persons can read meta data and manipulate checks.
+
+```yaml
+name: Lint
+on: [pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: eslint src --ext .ts,.js --format github
+        env:
+          ESLINT_APP_ID: ${{ secrets.ESLINT_APP_ID }}
+          ESLINT_PRIVATE_KEY_BASE64: ${{ secrets.ESLINT_PRIVATE_KEY_BASE64 }}
+```

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -97,6 +97,14 @@ export default async (results: eslint.CLIEngine.LintResult[]) => {
     warningCount += result.warningCount;
   });
 
+  let privateKey = process.env.ESLINT_PRIVATE_KEY || PRIVATE_KEY;
+  if (process.env.ESLINT_PRIVATE_KEY_BASE64) {
+    privateKey = Buffer.from(
+      process.env.ESLINT_PRIVATE_KEY_BASE64,
+      'base64'
+    ).toString();
+  }
+
   return createCheck({
     tool: 'ESLint',
     name: process.env.GH_CHECK_NAME || 'Check Code for Errors',
@@ -106,6 +114,6 @@ export default async (results: eslint.CLIEngine.LintResult[]) => {
     appId: process.env.ESLINT_APP_ID
       ? Number(process.env.ESLINT_APP_ID)
       : APP_ID,
-    privateKey: process.env.ESLINT_PRIVATE_KEY || PRIVATE_KEY
+    privateKey
   });
 };


### PR DESCRIPTION
@hipstersmoothie I am not really convinced to publish a PRIVATE_KEY with write permissions for checks in a public repository. But since there should be possibly good reasons for it, I find it Important to point in the README.md more to the "recommended" way. I have also introduced a ```ESLINT_PRIVATE_KEY_BASE64``` variable for this (#112 ).